### PR TITLE
fix: corrected maven configuration so it builds out of the box

### DIFF
--- a/Source/JRecord_Project/JRecord_Common/pom.xml
+++ b/Source/JRecord_Project/JRecord_Common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.sf.jrecord.jrecord-parent</groupId>
         <artifactId>jrecord-project-parent</artifactId>
-        <version>0.93.0</version>
+        <version>0.93</version>
     </parent>
 
     <groupId>net.sf.jrecord.jrecord-parent.jrecord-project-parent</groupId>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.sf</groupId>
             <artifactId>cb2xml_src</artifactId>
-            <version>1.01.4</version>
+            <version>1.01.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/Source/JRecord_Project/JRecord_IO_Builder_Examples/pom.xml
+++ b/Source/JRecord_Project/JRecord_IO_Builder_Examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.sf.jrecord-parent</groupId>
         <artifactId>jrecord-project-parent</artifactId>
-        <version>0.93.0</version>
+        <version>0.93</version>
     </parent>
 
     <groupId>net.sf.jrecord-project-parent</groupId>

--- a/Source/JRecord_Utilities/JRecord_Cbl2Csv/pom.xml
+++ b/Source/JRecord_Utilities/JRecord_Cbl2Csv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.sf.jrecord.jrecord-parent</groupId>
         <artifactId>jrecord-utilities-parent</artifactId>
-        <version>0.93.0</version>
+        <version>0.93</version>
     </parent>
 
     <groupId>net.sf.jrecord.jrecord-parent.jrecord-utilities-parent</groupId>

--- a/Source/JRecord_Utilities/JRecord_Cbl2Xml/pom.xml
+++ b/Source/JRecord_Utilities/JRecord_Cbl2Xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.sf.jrecord.jrecord-parent</groupId>
         <artifactId>jrecord-utilities-parent</artifactId>
-        <version>0.93.0</version>
+        <version>0.93</version>
     </parent>
 
     <groupId>net.sf.jrecord.jrecord-parent.jrecord-utilities-parent</groupId>

--- a/Source/JRecord_Utilities/JRecord_Examples_Classic/pom.xml
+++ b/Source/JRecord_Utilities/JRecord_Examples_Classic/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.sf.jrecord.jrecord-parent</groupId>
         <artifactId>jrecord-utilities-parent</artifactId>
-        <version>0.93.0</version>
+        <version>0.93</version>
     </parent>
 
     <groupId>net.sf.jrecord.jrecord-parent.jrecord-utilities-parent</groupId>

--- a/Source/JRecord_Utilities/JRecord_SchemaCompare/pom.xml
+++ b/Source/JRecord_Utilities/JRecord_SchemaCompare/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.sf.jrecord.jrecord-parent</groupId>
         <artifactId>jrecord-utilities-parent</artifactId>
-        <version>0.93.0</version>
+        <version>0.93</version>
     </parent>
 
     <groupId>net.sf.jrecord.jrecord-parent.jrecord-utilities-parent</groupId>
@@ -15,10 +15,10 @@
             <groupId>net.sf.jrecord.jrecord-parent.jrecord-project-parent</groupId>
             <artifactId>jrecord-base</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.sf.jrecord.jrecord-parent.jrecord-utilities-parent</groupId>
-            <artifactId>jrecord-cbl2json</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>net.sf.jrecord.jrecord-parent.jrecord-utilities-parent</groupId>-->
+<!--            <artifactId>jrecord-cbl2json</artifactId>-->
+<!--        </dependency>-->
     </dependencies>
 
     <build>


### PR DESCRIPTION
Updates to allow the project to build on checkout since there was a mismatch with versions.

Note, if you run `mvn versions:set`  when updating versions in the future it helps to avoid the mismatch